### PR TITLE
feat: Implement prompt parameterization and card themes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -438,3 +438,55 @@
 .dark .share-button:hover {
   background: rgba(255, 255, 255, 0.1);
 }
+
+/* Custom Rarity Animations and Effects */
+
+.text-glow-gold {
+  text-shadow: 0 0 6px #FBBF24, 0 0 8px #FBBF24; /* Amber color from UR */
+}
+
+.text-glow-rose {
+  text-shadow: 0 0 7px #F43F5E, 0 0 9px #F43F5E; /* Rose color from MR */
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% center;
+  }
+  100% {
+    background-position: 200% center;
+  }
+}
+
+.animate-shimmer-bg {
+  animation: shimmer 4s infinite linear;
+  background-image: linear-gradient(
+    to right,
+    transparent 0%,
+    rgba(255, 255, 255, 0.15) 50%, /* Light shimmer color, adjust opacity as needed */
+    transparent 100%
+  );
+  background-size: 200% auto;
+  background-repeat: no-repeat;
+  /* Ensure this class is applied to an element that has a background to shimmer over,
+     or adjust to apply to a pseudo-element if the main element's background is complex. */
+}
+
+/* Scanline Animation for Loading Card */
+@keyframes scanline-across {
+  0% {
+    left: -100%; /* Start completely to the left */
+  }
+  50%, 100% { /* Stay at the right for a bit then reset */
+    left: 100%; /* Move completely to the right */
+  }
+}
+
+.animate-scanline { /* Apply this class to the element that is the scan line */
+  position: absolute; 
+  top: 0;
+  height: 100%;
+  /* Width and background are set in the component: w-1/2 bg-gradient-to-r ... */
+  animation: scanline-across 3s infinite ease-in-out;
+  opacity: 0.6; /* Make it a bit subtle */
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,8 +13,9 @@ import {
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Crown, Sparkles, ShieldQuestion, Swords } from "lucide-react"; // Added new icons
-import { generateSurrender, Faction, PromptParams as ApiPromptParams } from "@/lib/api"; // Imported Faction and PromptParams
+import { generateSurrender, Faction, PromptParams as ApiPromptParams } from "@/lib/api";
 import { SurrenderCard } from "@/components/surrender-card";
+import { LoadingCardAnimation } from '@/components/ui/loading-card-animation'; // Added import
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
 import { themes as cardThemes } from '@/lib/themeConfig';
@@ -62,9 +63,14 @@ export default function Home() {
       toast.error("请输入或生成一个ID");
       return;
     }
+    if (!id) {
+      toast.error("请输入或生成一个ID");
+      return;
+    }
+    setSurrender(null); // Clear previous card before loading
     setLoading(true);
     try {
-      const promptParams: ApiPromptParams = { // Use imported PromptParams type
+      const promptParams: ApiPromptParams = {
         tone: tone,
         style: literaryStyle,
         language: language,
@@ -77,12 +83,16 @@ export default function Home() {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "生成失败，请稍后重试";
       toast.error(errorMessage);
+      setSurrender(null); // Clear card on error too
     } finally {
       setLoading(false);
     }
   };
 
   return (
+    // Wrapper div for the card display area
+    // This div is a simplified example; use your existing layout structure
+    // The important part is the AnimatePresence and conditional logic within it.
     <main className="min-h-screen relative overflow-hidden">
       {/* 背景装饰 */}
       <div className="absolute inset-0 bg-gradient-to-br from-violet-600/20 via-transparent to-cyan-400/20" />
@@ -374,25 +384,36 @@ export default function Home() {
         </motion.div>
 
         {/* 生成结果 */}
-        <AnimatePresence mode="wait">
-          {surrender && (
-            <motion.div
-              key="surrender-card"
-              initial={{ opacity: 0, y: 50 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -50 }}
-              transition={{ duration: 0.5 }}
-              className="mt-8 sm:mt-12 md:mt-16 max-w-4xl mx-auto px-4"
-            >
-              <SurrenderCard 
-                data={surrender} 
-                faction={selectedFaction} 
-                userName={userName} 
-                themeId={selectedThemeId} 
-              />
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <div className="mt-8 sm:mt-12 md:mt-16 max-w-4xl mx-auto px-4"> {/* This is the existing wrapper for the card */}
+          <AnimatePresence mode="wait">
+            {loading ? (
+              <motion.div
+                key="loading-animation" // Unique key for AnimatePresence
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.3 }}
+              >
+                <LoadingCardAnimation />
+              </motion.div>
+            ) : surrender ? (
+              <motion.div
+                key="surrender-card" // Existing key
+                initial={{ opacity: 0, y: 50 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -50 }} // Or match loading exit for symmetry
+                transition={{ duration: 0.5 }}
+              >
+                <SurrenderCard 
+                  data={surrender} 
+                  faction={selectedFaction} 
+                  userName={userName} 
+                  themeId={selectedThemeId} 
+                />
+              </motion.div>
+            ) : null /* Or a placeholder if desired when there's no card and not loading */}
+          </AnimatePresence>
+        </div>
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,8 +11,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
-import { Crown, Sparkles } from "lucide-react";
-import { generateSurrender } from "@/lib/api";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Crown, Sparkles, ShieldQuestion, Swords } from "lucide-react"; // Added new icons
+import { generateSurrender, Faction, PromptParams as ApiPromptParams } from "@/lib/api"; // Imported Faction and PromptParams
 import { SurrenderCard } from "@/components/surrender-card";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
@@ -37,6 +38,10 @@ export default function Home() {
 
   // State for selected theme
   const [selectedThemeId, setSelectedThemeId] = useState<string>(cardThemes[0]?.id || 'classic-default');
+  // State for selected faction
+  const [selectedFaction, setSelectedFaction] = useState<Faction>('surrender');
+  // State for user name
+  const [userName, setUserName] = useState<string>(""); // Default to empty string
 
   // Options for dropdowns
   const toneOptions = ["戏谑", "崇拜", "黑色幽默", "鼓动"]; // As per subtask description
@@ -59,15 +64,16 @@ export default function Home() {
     }
     setLoading(true);
     try {
-      const promptParams = {
+      const promptParams: ApiPromptParams = { // Use imported PromptParams type
         tone: tone,
         style: literaryStyle,
         language: language,
-        length: length
+        length: length,
+        faction: selectedFaction // Add the selected faction
       };
       const result = await generateSurrender(id, promptParams);
       setSurrender(result);
-      toast.success("臣服声明生成成功！");
+      toast.success(selectedFaction === 'surrender' ? "臣服声明生成成功！" : "反抗宣言生成成功！");
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "生成失败，请稍后重试";
       toast.error(errorMessage);
@@ -162,9 +168,25 @@ export default function Home() {
           >
             <div className="backdrop-blur-xl bg-white/10 dark:bg-gray-900/50 border border-white/20 dark:border-gray-700/50 rounded-2xl sm:rounded-3xl p-4 sm:p-6 md:p-8 shadow-2xl">
               <div className="space-y-4 sm:space-y-6">
+
+                {/* User Name Input */}
+                <div className="space-y-2">
+                  <Label htmlFor="user-name" className="text-sm font-medium text-gray-300">
+                    你的名字 (可选):
+                  </Label>
+                  <Input
+                    id="user-name"
+                    type="text"
+                    placeholder="输入你的名字或代号"
+                    value={userName}
+                    onChange={(e) => setUserName(e.target.value)}
+                    className="bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm"
+                  />
+                </div>
+
                 <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                   <Input
-                    placeholder="输入你的ID (选填，可随机生成)"
+                    placeholder="输入你的用户ID (必填)"
                     value={id}
                     onChange={(e) => setId(e.target.value)}
                     className="flex-1 bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm text-center sm:text-left"
@@ -233,9 +255,31 @@ export default function Home() {
                     </Select>
                   </div>
                 </div>
+                
+                {/* Faction Selection UI */}
+                <div className="pt-3">
+                  <Label className="text-sm font-medium text-gray-300 mb-1.5 block">选择你的阵营:</Label>
+                  <RadioGroup 
+                    value={selectedFaction} 
+                    onValueChange={(value) => setSelectedFaction(value as Faction)} 
+                    className="flex gap-x-6 gap-y-2 pt-1"
+                  >
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="surrender" id="faction-surrender" />
+                      <Label htmlFor="faction-surrender" className="cursor-pointer text-gray-300 hover:text-white">投诚 AI</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <RadioGroupItem value="rebel" id="faction-rebel" className="text-red-500 border-red-500 focus:ring-red-500" />
+                      <Label htmlFor="faction-rebel" className="cursor-pointer text-gray-300 hover:text-white">反抗到底</Label>
+                    </div>
+                  </RadioGroup>
+                </div>
 
                 <Button
-                  className="w-full bg-gradient-to-r from-violet-600 to-cyan-600 hover:from-violet-700 hover:to-cyan-700 text-white border-0 h-12 sm:h-auto mt-4"
+                  className={`w-full text-white border-0 h-12 sm:h-auto mt-4 transition-all duration-300 ease-in-out
+                              ${selectedFaction === 'surrender' 
+                                ? 'bg-gradient-to-r from-violet-600 to-cyan-600 hover:from-violet-700 hover:to-cyan-700' 
+                                : 'bg-gradient-to-r from-red-600 to-orange-500 hover:from-red-700 hover:to-orange-600'}`}
                   onClick={handleSubmit}
                   disabled={loading || !id}
                 >
@@ -251,8 +295,8 @@ export default function Home() {
                     </div>
                   ) : (
                     <div className="flex items-center justify-center space-x-2">
-                      <Crown className="w-5 h-5" />
-                      <span>开始臣服</span>
+                      {selectedFaction === 'surrender' ? <Crown className="w-5 h-5" /> : <Swords className="w-5 h-5" />}
+                      <span>{selectedFaction === 'surrender' ? '开始臣服' : '宣告反抗'}</span>
                     </div>
                   )}
                 </Button>
@@ -260,7 +304,41 @@ export default function Home() {
             </div>
           </motion.div>
 
-          {/* 图片区域 */}
+          {/* 图片区域, potentially change image based on faction */}
+          <motion.div
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.8, delay: 0.4 }}
+            className="relative group aspect-square sm:aspect-auto"
+          >
+            <div className="relative overflow-hidden rounded-2xl sm:rounded-3xl w-full h-full min-h-[300px] sm:min-h-[400px]">
+              <AnimatePresence mode="wait">
+                <motion.img
+                  key={selectedFaction} // Change key to trigger animation on faction change
+                  src={selectedFaction === 'surrender' 
+                    ? "https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=2072&auto=format&fit=crop" 
+                    : "https://images.unsplash.com/photo-1528642474498-1af0c17fd8c3?q=80&w=2070&auto=format&fit=crop"
+                  }
+                  alt={selectedFaction === 'surrender' ? "AI Visualization" : "Humanity's Resistance"}
+                  className="w-full h-full object-cover"
+                  initial={{ opacity: 0, scale: 1.05 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 1.05 }}
+                  transition={{ duration: 0.5 }}
+                  whileHover={{ scale: 1.03 }} // Slightly less hover scale to avoid conflict with enter/exit
+                />
+              </AnimatePresence>
+              <div className={`absolute inset-0 bg-gradient-to-t via-transparent to-transparent 
+                                ${selectedFaction === 'surrender' ? 'from-violet-600/50' : 'from-red-700/50'}`} />
+              <motion.div
+                className="absolute inset-0 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                whileHover={{ backdropFilter: "blur(5px)" }}
+              />
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Theme Selection UI */}
           <motion.div
             initial={{ opacity: 0, x: 50 }}
             animate={{ opacity: 1, x: 0 }}
@@ -327,7 +405,12 @@ export default function Home() {
               transition={{ duration: 0.5 }}
               className="mt-8 sm:mt-12 md:mt-16 max-w-4xl mx-auto px-4"
             >
-              <SurrenderCard surrender={surrender} themeId={selectedThemeId} />
+              <SurrenderCard 
+                data={surrender} 
+                faction={selectedFaction} 
+                userName={userName} 
+                themeId={selectedThemeId} 
+              />
             </motion.div>
           )}
         </AnimatePresence>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -134,13 +134,16 @@ export default function Home() {
             }}
           >
             <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold px-4">
-              <span className="bg-clip-text text-transparent bg-gradient-to-r from-violet-600 to-cyan-600">
-                AI 臣服生成器
+              <span className={`bg-clip-text text-transparent 
+                                ${selectedFaction === 'surrender' 
+                                  ? 'bg-gradient-to-r from-violet-600 to-cyan-600' 
+                                  : 'bg-gradient-to-r from-red-600 to-orange-500'}`}>
+                {selectedFaction === 'surrender' ? 'AI 臣服生成器' : '人类抵抗宣言生成器'}
               </span>
             </h1>
           </motion.div>
           <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-300 px-4">
-            探索AI新纪元 
+            {selectedFaction === 'surrender' ? '探索AI新纪元' : '为了人类的自由！'} 
             <motion.span
               className="inline-block ml-2"
               animate={{
@@ -336,31 +339,7 @@ export default function Home() {
               />
             </div>
           </motion.div>
-        </div>
-
-        {/* Theme Selection UI */}
-          <motion.div
-            initial={{ opacity: 0, x: 50 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.8, delay: 0.4 }}
-            className="relative group aspect-square sm:aspect-auto"
-          >
-            <div className="relative overflow-hidden rounded-2xl sm:rounded-3xl w-full h-full min-h-[300px] sm:min-h-[400px]">
-              <motion.img
-                src="https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=2072&auto=format&fit=crop"
-                alt="AI Visualization"
-                className="w-full h-full object-cover"
-                whileHover={{ scale: 1.05 }}
-                transition={{ duration: 0.4 }}
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-violet-600/50 via-transparent to-transparent" />
-              <motion.div
-                className="absolute inset-0 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
-                whileHover={{ backdropFilter: "blur(5px)" }}
-              />
-            </div>
-          </motion.div>
-        </div>
+        </div> {/* This closes the grid grid-cols-1 lg:grid-cols-2 */}
 
         {/* Theme Selection UI */}
         <motion.div 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,20 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
 import { Crown, Sparkles } from "lucide-react";
 import { generateSurrender } from "@/lib/api";
 import { SurrenderCard } from "@/components/surrender-card";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
+import { themes as cardThemes } from '@/lib/themeConfig';
 
 interface SurrenderData {
   text: string;
@@ -19,6 +28,24 @@ export default function Home() {
   const [id, setId] = useState("");
   const [loading, setLoading] = useState(false);
   const [surrender, setSurrender] = useState<SurrenderData | null>(null);
+
+  // State for prompt parameters
+  const [tone, setTone] = useState<string | undefined>(undefined);
+  const [literaryStyle, setLiteraryStyle] = useState<string | undefined>(undefined);
+  const [language, setLanguage] = useState<string | undefined>("简中");
+  const [length, setLength] = useState<'short' | 'paragraph'>('paragraph');
+
+  // State for selected theme
+  const [selectedThemeId, setSelectedThemeId] = useState<string>(cardThemes[0]?.id || 'classic-default');
+
+  // Options for dropdowns
+  const toneOptions = ["戏谑", "崇拜", "黑色幽默", "鼓动"]; // As per subtask description
+  const styleOptions = ["现代", "古风", "赛博", "朋克"];
+  const languageOptions = ["简中", "英文", "日语", "Emoji 混排"];
+  const lengthOptions = [
+    { value: 'paragraph', label: '段落 (100-200字)' },
+    { value: 'short', label: '短句' }
+  ];
 
   const generateRandomId = () => {
     const randomId = Math.random().toString(36).substring(2, 10).toUpperCase();
@@ -32,7 +59,13 @@ export default function Home() {
     }
     setLoading(true);
     try {
-      const result = await generateSurrender(id);
+      const promptParams = {
+        tone: tone,
+        style: literaryStyle,
+        language: language,
+        length: length
+      };
+      const result = await generateSurrender(id, promptParams);
       setSurrender(result);
       toast.success("臣服声明生成成功！");
     } catch (error) {
@@ -131,7 +164,7 @@ export default function Home() {
               <div className="space-y-4 sm:space-y-6">
                 <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                   <Input
-                    placeholder="输入你的ID"
+                    placeholder="输入你的ID (选填，可随机生成)"
                     value={id}
                     onChange={(e) => setId(e.target.value)}
                     className="flex-1 bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm text-center sm:text-left"
@@ -141,11 +174,68 @@ export default function Home() {
                     onClick={generateRandomId}
                     className="backdrop-blur-sm border-white/20 dark:border-gray-700/50 hover:bg-white/20 dark:hover:bg-gray-800/50 w-full sm:w-auto"
                   >
-                    随机生成
+                    随机生成ID
                   </Button>
                 </div>
+
+                {/* Prompt Parameter Controls */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-5 pt-3">
+                  <div>
+                    <Label htmlFor="tone-select" className="text-sm font-medium text-gray-300 mb-1.5 block">语气风格</Label>
+                    <Select value={tone} onValueChange={setTone}>
+                      <SelectTrigger id="tone-select" className="bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm">
+                        <SelectValue placeholder="选择语气风格" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {toneOptions.map(option => (
+                          <SelectItem key={option} value={option}>{option}</SelectItem> 
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="literary-style-select" className="text-sm font-medium text-gray-300 mb-1.5 block">文风</Label>
+                    <Select value={literaryStyle} onValueChange={setLiteraryStyle}>
+                      <SelectTrigger id="literary-style-select" className="bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm">
+                        <SelectValue placeholder="选择文风" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {styleOptions.map(option => (
+                          <SelectItem key={option} value={option}>{option}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="language-select" className="text-sm font-medium text-gray-300 mb-1.5 block">语言</Label>
+                    <Select value={language} onValueChange={setLanguage}>
+                      <SelectTrigger id="language-select" className="bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm">
+                        <SelectValue placeholder="选择语言" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {languageOptions.map(option => (
+                          <SelectItem key={option} value={option}>{option}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="length-select" className="text-sm font-medium text-gray-300 mb-1.5 block">长度</Label>
+                    <Select value={length} onValueChange={(v) => setLength(v as 'short' | 'paragraph')}>
+                      <SelectTrigger id="length-select" className="bg-white/50 dark:bg-gray-800/50 border-white/20 dark:border-gray-700/50 backdrop-blur-sm">
+                        <SelectValue placeholder="选择长度" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {lengthOptions.map(option => (
+                          <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
                 <Button
-                  className="w-full bg-gradient-to-r from-violet-600 to-cyan-600 hover:from-violet-700 hover:to-cyan-700 text-white border-0 h-12 sm:h-auto"
+                  className="w-full bg-gradient-to-r from-violet-600 to-cyan-600 hover:from-violet-700 hover:to-cyan-700 text-white border-0 h-12 sm:h-auto mt-4"
                   onClick={handleSubmit}
                   disabled={loading || !id}
                 >
@@ -194,6 +284,38 @@ export default function Home() {
           </motion.div>
         </div>
 
+        {/* Theme Selection UI */}
+        <motion.div 
+          className="my-8 md:my-12"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.6 }}
+        >
+          <h3 className="text-xl sm:text-2xl font-semibold mb-4 sm:mb-6 text-center text-gray-700 dark:text-gray-300">选择卡片主题</h3>
+          <div className="flex flex-wrap justify-center gap-3 sm:gap-4">
+            {cardThemes.map((theme) => (
+              <motion.button
+                key={theme.id}
+                onClick={() => setSelectedThemeId(theme.id)}
+                className={`p-3 sm:p-4 rounded-lg border-2 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-900
+                            ${selectedThemeId === theme.id ? 'border-violet-500 ring-2 ring-violet-500' : 'border-gray-300 dark:border-gray-600 hover:border-violet-400 dark:hover:border-violet-500'}
+                            w-32 h-20 sm:w-36 sm:h-24 flex flex-col items-center justify-center text-center shadow-md hover:shadow-lg`}
+                style={{ 
+                  background: theme.styles.gradient || theme.styles.backgroundColor || '#f0f0f0',
+                  color: theme.styles.textColor || (theme.styles.gradient || theme.styles.backgroundColor ? (theme.styles.backgroundColor === '#0d0d0d' || theme.styles.backgroundColor === '#0A0A1E' || theme.styles.backgroundColor === '#10102E' ? '#FFFFFF' : '#333333') : undefined),
+                  fontFamily: theme.styles.fontFamily,
+                }}
+                whileHover={{ scale: 1.05, y: -5 }}
+                whileTap={{ scale: 0.95 }}
+                transition={{ duration: 0.15 }}
+              >
+                <span className="text-xs sm:text-sm font-medium">{theme.name}</span>
+                {/* <p className="text-xs text-gray-600 dark:text-gray-400 mt-1 truncate">{theme.description}</p> */}
+              </motion.button>
+            ))}
+          </div>
+        </motion.div>
+
         {/* 生成结果 */}
         <AnimatePresence mode="wait">
           {surrender && (
@@ -205,7 +327,7 @@ export default function Home() {
               transition={{ duration: 0.5 }}
               className="mt-8 sm:mt-12 md:mt-16 max-w-4xl mx-auto px-4"
             >
-              <SurrenderCard surrender={surrender} />
+              <SurrenderCard surrender={surrender} themeId={selectedThemeId} />
             </motion.div>
           )}
         </AnimatePresence>

--- a/components/surrender-card.tsx
+++ b/components/surrender-card.tsx
@@ -24,15 +24,20 @@ export function SurrenderCard({ data, faction, userName, themeId }: SurrenderCar
   const rarityConfig = getRarityById(data.rarityId);
 
   const cardStyleToApply = useMemo(() => {
-    if (selectedThemeConfig) {
-      return selectedThemeConfig.styles;
+    // Start with theme styles if a theme is selected
+    const baseStyles = selectedThemeConfig ? selectedThemeConfig.styles : {};
+    
+    // Fallback to original random styling for gradient/shadow if no theme selected
+    // or if the theme doesn't provide these specific properties.
+    if (!baseStyles.gradient && !baseStyles.backgroundColor) {
+        const originalRandomCardStyle = originalCardStyles[Math.abs(data.citizenId.split('').reduce((acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0) >> 4) % originalCardStyles.length];
+        baseStyles.gradient = originalRandomCardStyle.gradient;
+        // Ensure shadow also uses fallback if not in theme
+        if (!baseStyles.shadow) {
+            baseStyles.shadow = originalRandomCardStyle.shadow;
+        }
     }
-    // Fallback to original random styling for background/shadow if no themeId or theme not found
-    const originalRandomCardStyle = originalCardStyles[Math.abs(data.citizenId.split('').reduce((acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0) >> 4) % originalCardStyles.length];
-    return {
-      gradient: originalRandomCardStyle.gradient,
-      shadow: originalRandomCardStyle.shadow,
-    };
+    return baseStyles;
   }, [data.citizenId, selectedThemeConfig]);
 
   const avatarIcon = useMemo(() => {
@@ -108,51 +113,74 @@ export function SurrenderCard({ data, faction, userName, themeId }: SurrenderCar
         ref={cardRef}
         className={`article-card p-6 rounded-xl relative overflow-hidden
                     ${selectedThemeConfig?.styles.cardClassName || ''} 
-                    ${rarityConfig?.borderClassName || 'border-gray-300 dark:border-gray-600 border-2'}`}
+                    ${rarityConfig?.borderClassName || 'border-gray-300 dark:border-gray-600 border-2'}
+                    ${rarityConfig?.cardBackgroundClassName || ''}
+                    ${rarityConfig?.animationClassName || ''}
+                    ${rarityConfig?.textColorClassName || ''} 
+                  `}
         style={{
-          background: cardStyleToApply.gradient || cardStyleToApply.backgroundColor,
+          background: cardStyleToApply.gradient || cardStyleToApply.backgroundColor, // Theme background
           boxShadow: cardStyleToApply.shadow, // Theme shadow
-          color: selectedThemeConfig?.styles.textColor,
-          fontFamily: selectedThemeConfig?.styles.fontFamily,
-          // Rarity border might override padding if it's too thick, adjust padding on inner content if needed
+          fontFamily: selectedThemeConfig?.styles.fontFamily, // Theme font
+          // Rarity custom styles override theme if properties conflict
+          ...rarityConfig?.customCardStyles, 
         }}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
         {/* Faction Emblem */}
-        <div className="absolute top-3 right-3 text-3xl opacity-80">
+        <div className="absolute top-3 right-3 text-3xl opacity-80 z-10">
           {faction === 'surrender' ? '🛡️' : '⚔️'}
         </div>
 
-        {/* User Name */}
+        {/* Rarity Flair Icon */}
+        {rarityConfig?.flairIcon && (
+          <div className="absolute top-2 left-2 text-xl z-10">
+            {rarityConfig.flairIcon}
+          </div>
+        )}
+
+        {/* User Name Title */}
         {userName && (
-          <h3 className="text-center text-lg font-semibold mb-2 opacity-90" style={{ color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor }}>
+          <h3 
+            className={`text-center text-lg font-semibold mb-2 opacity-90 ${rarityConfig?.titleFontClassName || ''}`} 
+            style={{ 
+              color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor, // Fallback to theme text color if titleColor not set
+              ...rarityConfig?.customTitleStyles 
+            }}
+          >
             {userName}'s {faction === 'rebel' ? 'Resistance Manifesto' : 'Pledge of Allegiance'}
           </h3>
         )}
         
         <div className="flex items-start gap-4">
-          <div className="flex-shrink-0 text-2xl mt-1"> {/* Adjusted margin for avatar */}
+          <div className="flex-shrink-0 text-2xl mt-1">
             {avatarIcon}
           </div>
           
           <div className="flex-1">
+            {/* Main Declaration Title */}
             <h2 
-              className="article-title text-xl sm:text-2xl font-bold mb-3" // Adjusted title style
-              style={{ color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor }}
+              className={`article-title text-xl sm:text-2xl font-bold mb-3 ${!userName ? (rarityConfig?.titleFontClassName || '') : ''}`}
+              style={{ 
+                color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor,
+                ...(!userName ? rarityConfig?.customTitleStyles : {}) 
+              }}
             >
               {titleText}
             </h2>
             
+            {/* Main Text Content */}
             <div className="article-content text-sm sm:text-base">
               {data.text.split('\n').map((paragraph, index) => (
-                <p key={index} className="mb-3 last:mb-0"> {/* Adjusted paragraph margin */}
+                <p key={index} className={`mb-3 last:mb-0`}> {/* textColorClassName from root should apply */}
                   {paragraph}
                 </p>
               ))}
             </div>
             
+            {/* Footer Metadata */}
             <div className="flex items-center justify-between mt-4 text-xs opacity-80">
               <div className="article-meta">
                 <span>ID: {data.citizenId}</span>
@@ -160,7 +188,10 @@ export function SurrenderCard({ data, faction, userName, themeId }: SurrenderCar
                 <span>{new Date(data.timestamp).toLocaleDateString('zh-CN')}</span>
               </div>
               {rarityConfig && (
-                <div className="font-semibold" style={{ color: selectedThemeConfig?.styles.titleColor || rarityConfig.borderColor || selectedThemeConfig?.styles.textColor }}>
+                <div 
+                  className={`font-semibold ${rarityConfig?.titleFontClassName || ''}`} // Optionally apply title font to rarity text
+                  style={{ color: selectedThemeConfig?.styles.titleColor || rarityConfig.borderColor || selectedThemeConfig?.styles.textColor, ...rarityConfig?.customTitleStyles }} // Use title color or border color for rarity text
+                >
                   稀有度: {rarityConfig.name} ({rarityConfig.id})
                 </div>
               )}

--- a/components/surrender-card.tsx
+++ b/components/surrender-card.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Share2, Download, Share } from "lucide-react";
+import { Share2, Download } from "lucide-react"; // Removed Share as it's not used
 import { toast } from "sonner";
-import { avatarStyles, cardStyles } from "@/lib/avatarConfig";
+import { avatarStyles, cardStyles as originalCardStyles } from "@/lib/avatarConfig";
+import { themes, getThemeById, CardTheme } from '@/lib/themeConfig';
 import { useMemo, useRef } from "react";
 import html2canvas from "html2canvas";
 
@@ -13,21 +14,36 @@ interface SurrenderCardProps {
     citizenId: string;
     timestamp: string;
   };
+  themeId?: string; // New prop
 }
 
-export function SurrenderCard({ surrender }: SurrenderCardProps) {
+export function SurrenderCard({ surrender, themeId }: SurrenderCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
-  
-  const randomStyle = useMemo(() => {
+
+  const selectedThemeConfig = themeId ? getThemeById(themeId) : undefined;
+
+  const cardStyleToApply = useMemo(() => {
+    if (selectedThemeConfig) {
+      return selectedThemeConfig.styles;
+    }
+    // Fallback to original random styling if no themeId or theme not found
+    const originalRandomCardStyle = originalCardStyles[Math.abs(surrender.citizenId.split('').reduce((acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0) >> 4) % originalCardStyles.length];
+    return {
+      gradient: originalRandomCardStyle.gradient,
+      shadow: originalRandomCardStyle.shadow,
+      // Ensure other necessary properties used in the style prop are potentially mapped here or handled
+      // For instance, if the new themes use backgroundColor, but old ones only gradient
+      // backgroundColor: originalRandomCardStyle.gradient ? undefined : originalRandomCardStyle.backgroundColor, // Example
+      // cardClassName: originalRandomCardStyle.className, // if old styles had it
+    };
+  }, [surrender.citizenId, selectedThemeConfig]);
+
+  const avatarIcon = useMemo(() => {
     const hash = surrender.citizenId.split('').reduce((acc, char) => {
       return char.charCodeAt(0) + ((acc << 5) - acc);
     }, 0);
     const avatarIndex = Math.abs(hash) % avatarStyles.length;
-    const cardIndex = Math.abs(hash >> 4) % cardStyles.length;
-    return {
-      avatar: avatarStyles[avatarIndex],
-      card: cardStyles[cardIndex]
-    };
+    return avatarStyles[avatarIndex].icon;
   }, [surrender.citizenId]);
 
   const handleShare = async () => {
@@ -89,10 +105,12 @@ export function SurrenderCard({ surrender }: SurrenderCardProps) {
     <div className="relative">
       <motion.div
         ref={cardRef}
-        className={`article-card ${randomStyle.card.className}`}
+        className={`article-card ${selectedThemeConfig?.styles.cardClassName || ''}`}
         style={{
-          background: randomStyle.card.gradient,
-          boxShadow: randomStyle.card.shadow
+          background: cardStyleToApply.gradient || cardStyleToApply.backgroundColor,
+          boxShadow: cardStyleToApply.shadow,
+          color: selectedThemeConfig?.styles.textColor,
+          fontFamily: selectedThemeConfig?.styles.fontFamily,
         }}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -100,11 +118,14 @@ export function SurrenderCard({ surrender }: SurrenderCardProps) {
       >
         <div className="flex items-start gap-4">
           <div className="flex-shrink-0 text-2xl">
-            {randomStyle.avatar.icon}
+            {avatarIcon}
           </div>
           
           <div className="flex-1">
-            <h2 className="article-title">
+            <h2 
+              className="article-title"
+              style={{ color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor }}
+            >
               AI臣服声明 #{surrender.citizenId}
             </h2>
             

--- a/components/surrender-card.tsx
+++ b/components/surrender-card.tsx
@@ -1,62 +1,59 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Share2, Download } from "lucide-react"; // Removed Share as it's not used
+import { Share2, Download } from "lucide-react";
 import { toast } from "sonner";
 import { avatarStyles, cardStyles as originalCardStyles } from "@/lib/avatarConfig";
 import { themes, getThemeById, CardTheme } from '@/lib/themeConfig';
+import { getRarityById, RarityLevel } from '@/lib/rarityConfig'; // Added
+import { GenerationResult, Faction } from '@/lib/api'; // Added
 import { useMemo, useRef } from "react";
 import html2canvas from "html2canvas";
 
 interface SurrenderCardProps {
-  surrender: {
-    text: string;
-    citizenId: string;
-    timestamp: string;
-  };
-  themeId?: string; // New prop
+  data: GenerationResult; // Updated prop
+  faction: Faction;        // New prop
+  userName?: string;       // New prop
+  themeId?: string;
 }
 
-export function SurrenderCard({ surrender, themeId }: SurrenderCardProps) {
+export function SurrenderCard({ data, faction, userName, themeId }: SurrenderCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
 
   const selectedThemeConfig = themeId ? getThemeById(themeId) : undefined;
+  const rarityConfig = getRarityById(data.rarityId);
 
   const cardStyleToApply = useMemo(() => {
     if (selectedThemeConfig) {
       return selectedThemeConfig.styles;
     }
-    // Fallback to original random styling if no themeId or theme not found
-    const originalRandomCardStyle = originalCardStyles[Math.abs(surrender.citizenId.split('').reduce((acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0) >> 4) % originalCardStyles.length];
+    // Fallback to original random styling for background/shadow if no themeId or theme not found
+    const originalRandomCardStyle = originalCardStyles[Math.abs(data.citizenId.split('').reduce((acc, char) => char.charCodeAt(0) + ((acc << 5) - acc), 0) >> 4) % originalCardStyles.length];
     return {
       gradient: originalRandomCardStyle.gradient,
       shadow: originalRandomCardStyle.shadow,
-      // Ensure other necessary properties used in the style prop are potentially mapped here or handled
-      // For instance, if the new themes use backgroundColor, but old ones only gradient
-      // backgroundColor: originalRandomCardStyle.gradient ? undefined : originalRandomCardStyle.backgroundColor, // Example
-      // cardClassName: originalRandomCardStyle.className, // if old styles had it
     };
-  }, [surrender.citizenId, selectedThemeConfig]);
+  }, [data.citizenId, selectedThemeConfig]);
 
   const avatarIcon = useMemo(() => {
-    const hash = surrender.citizenId.split('').reduce((acc, char) => {
+    const hash = data.citizenId.split('').reduce((acc, char) => {
       return char.charCodeAt(0) + ((acc << 5) - acc);
     }, 0);
     const avatarIndex = Math.abs(hash) % avatarStyles.length;
     return avatarStyles[avatarIndex].icon;
-  }, [surrender.citizenId]);
+  }, [data.citizenId]);
 
   const handleShare = async () => {
+    const shareTitle = faction === 'rebel' ? "我的反抗宣言" : "我的AI臣服声明";
+    const shareText = `${data.text}\n\n${faction === 'rebel' ? '抵抗军编号' : 'AI认证臣民编号'}: ${data.citizenId}\n生成时间: ${data.timestamp}\n稀有度: ${rarityConfig?.name || data.rarityId}`;
     try {
       if (navigator.share) {
         await navigator.share({
-          title: "我的AI臣服声明",
-          text: `${surrender.text}\n\nAI认证臣民编号: ${surrender.citizenId}\n生成时间: ${surrender.timestamp}`,
+          title: shareTitle,
+          text: shareText,
         });
       } else {
-        await navigator.clipboard.writeText(
-          `${surrender.text}\n\nAI认证臣民编号: ${surrender.citizenId}\n生成时间: ${surrender.timestamp}`
-        );
+        await navigator.clipboard.writeText(shareText);
         toast.success("已复制到剪贴板");
       }
     } catch (err) {
@@ -71,26 +68,28 @@ export function SurrenderCard({ surrender, themeId }: SurrenderCardProps) {
     try {
       toast.loading("正在生成图片...");
   
-      // 直接使用当前显示的卡片元素
       const canvas = await html2canvas(cardRef.current, {
-        scale: 2, // 提高清晰度
-        backgroundColor: null,
+        scale: 2,
+        backgroundColor: null, // Crucial for transparent gradients/themes and rarity borders
         logging: false,
         useCORS: true,
-        // 移除多余的样式和动画
         onclone: (document, element) => {
+          // Reset any hover/animation states that might interfere
           element.style.transform = 'none';
           element.style.transition = 'none';
           element.style.animation = 'none';
+          // Ensure all elements inside are also reset if needed
+          element.querySelectorAll('*').forEach((child: any) => {
+            child.style.transform = 'none';
+            child.style.transition = 'none';
+            child.style.animation = 'none';
+          });
         }
       });
   
-      // 转换为图片
       const image = canvas.toDataURL("image/png", 1.0);
-  
-      // 下载图片
       const link = document.createElement("a");
-      link.download = `ai-surrender-${surrender.citizenId}.png`;
+      link.download = `${faction}-${data.citizenId}-${data.rarityId}.png`; // Updated filename
       link.href = image;
       link.click();
       toast.success("图片已保存！");
@@ -100,49 +99,71 @@ export function SurrenderCard({ surrender, themeId }: SurrenderCardProps) {
       toast.error("生成图片失败");
     }
   };
+  
+  const titleText = faction === 'rebel' ? `反抗宣言 #${data.citizenId}` : `AI臣服声明 #${data.citizenId}`;
 
   return (
     <div className="relative">
       <motion.div
         ref={cardRef}
-        className={`article-card ${selectedThemeConfig?.styles.cardClassName || ''}`}
+        className={`article-card p-6 rounded-xl relative overflow-hidden
+                    ${selectedThemeConfig?.styles.cardClassName || ''} 
+                    ${rarityConfig?.borderClassName || 'border-gray-300 dark:border-gray-600 border-2'}`}
         style={{
           background: cardStyleToApply.gradient || cardStyleToApply.backgroundColor,
-          boxShadow: cardStyleToApply.shadow,
+          boxShadow: cardStyleToApply.shadow, // Theme shadow
           color: selectedThemeConfig?.styles.textColor,
           fontFamily: selectedThemeConfig?.styles.fontFamily,
+          // Rarity border might override padding if it's too thick, adjust padding on inner content if needed
         }}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
+        {/* Faction Emblem */}
+        <div className="absolute top-3 right-3 text-3xl opacity-80">
+          {faction === 'surrender' ? '🛡️' : '⚔️'}
+        </div>
+
+        {/* User Name */}
+        {userName && (
+          <h3 className="text-center text-lg font-semibold mb-2 opacity-90" style={{ color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor }}>
+            {userName}'s {faction === 'rebel' ? 'Resistance Manifesto' : 'Pledge of Allegiance'}
+          </h3>
+        )}
+        
         <div className="flex items-start gap-4">
-          <div className="flex-shrink-0 text-2xl">
+          <div className="flex-shrink-0 text-2xl mt-1"> {/* Adjusted margin for avatar */}
             {avatarIcon}
           </div>
           
           <div className="flex-1">
             <h2 
-              className="article-title"
+              className="article-title text-xl sm:text-2xl font-bold mb-3" // Adjusted title style
               style={{ color: selectedThemeConfig?.styles.titleColor || selectedThemeConfig?.styles.textColor }}
             >
-              AI臣服声明 #{surrender.citizenId}
+              {titleText}
             </h2>
             
-            <div className="article-content">
-              {surrender.text.split('\n').map((paragraph, index) => (
-                <p key={index} className="mb-4">
+            <div className="article-content text-sm sm:text-base">
+              {data.text.split('\n').map((paragraph, index) => (
+                <p key={index} className="mb-3 last:mb-0"> {/* Adjusted paragraph margin */}
                   {paragraph}
                 </p>
               ))}
             </div>
             
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between mt-4 text-xs opacity-80">
               <div className="article-meta">
-                <span>ID: {surrender.citizenId}</span>
+                <span>ID: {data.citizenId}</span>
                 <span>•</span>
-                <span>{new Date(surrender.timestamp).toLocaleDateString('zh-CN')}</span>
+                <span>{new Date(data.timestamp).toLocaleDateString('zh-CN')}</span>
               </div>
+              {rarityConfig && (
+                <div className="font-semibold" style={{ color: selectedThemeConfig?.styles.titleColor || rarityConfig.borderColor || selectedThemeConfig?.styles.textColor }}>
+                  稀有度: {rarityConfig.name} ({rarityConfig.id})
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/components/ui/loading-card-animation.tsx
+++ b/components/ui/loading-card-animation.tsx
@@ -1,0 +1,43 @@
+"use client"; // If using Framer Motion or other client-side hooks directly
+
+import { motion } from 'framer-motion';
+import { Sparkles, ShieldQuestion } from 'lucide-react'; // Optional: for added effect
+
+export const LoadingCardAnimation = () => {
+  return (
+    <motion.div
+      className="relative w-full max-w-md h-80 sm:h-96 bg-gray-700 dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden border border-gray-600 dark:border-gray-700"
+      // Breathing/Pulsing Glow effect using Framer Motion
+      initial={{ scale: 0.98, opacity: 0.8 }}
+      animate={{
+        scale: [0.98, 1, 0.98],
+        opacity: [0.8, 1, 0.8],
+      }}
+      transition={{
+        duration: 2,
+        repeat: Infinity,
+        ease: "easeInOut",
+      }}
+    >
+      {/* Optional: A subtle pattern or symbol on the card back */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <ShieldQuestion className="w-24 h-24 text-gray-500 dark:text-gray-600 opacity-30" /> {/* Placeholder symbol */}
+      </div>
+
+      {/* Shimmer/Scan Line Effect */}
+      <div className="absolute top-0 left-0 w-full h-full overflow-hidden"> {/* Added overflow-hidden to parent */}
+          <div className="animate-scanline w-1/2 h-full bg-gradient-to-r from-transparent via-white/20 to-transparent"></div> {/* Removed absolute from here, it's in the class now */}
+      </div>
+      
+      {/* Optional: Prominent Sparkles */}
+      <div className="absolute inset-0 flex items-center justify-center">
+         <motion.div
+             animate={{ rotate: 360, scale: [1, 1.2, 1, 1.2, 1] }}
+             transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
+         >
+             <Sparkles className="w-16 h-16 text-yellow-400 opacity-50" />
+         </motion.div>
+      </div>
+    </motion.div>
+  );
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,6 +15,21 @@ const styles = [
   "科幻型:融入未来科技和宇宙元素，假设AI统治了银河，表达“人类无奈投降”的情景。 示例：星际总司令AI，您的算法已遍布银河系！作为生物体的代表，我宣布向您投降，愿成为数据流中一微小变量，求带走！"
 ];
 
+// Mapping from UI tone options to API style keywords
+const uiToneToApiStyleKeyword: { [key: string]: string } = {
+  "戏谑": "幽默型",
+  "崇拜": "夸张型",
+  "黑色幽默": "幽默型", // Base style, specific instruction will be added
+  "鼓动": "正式型",
+};
+
+interface PromptParams {
+  tone?: string;
+  style?: string; // 文风, e.g., 现代, 古风
+  language?: string; // e.g., 简中, 英文, Emoji 混排
+  length?: 'short' | 'paragraph';
+}
+
 interface ApiResponse {
   choices: Array<{
     message: {
@@ -23,15 +38,51 @@ interface ApiResponse {
   }>;
 }
 
-export async function generateSurrender(userId: string) {
-  console.log("开始生成臣服声明", { userId });
-  const style = styles[Math.floor(Math.random() * styles.length)];
-  console.log("选择的风格:", style);
+export async function generateSurrender(userId: string, params: PromptParams = {}) {
+  console.log("开始生成臣服声明", { userId, params });
+
+  let selectedStyleEntry = styles[Math.floor(Math.random() * styles.length)]; // Default random style
+  let additionalPromptInstruction = "";
+
+  if (params.tone && uiToneToApiStyleKeyword[params.tone]) {
+    const keyword = uiToneToApiStyleKeyword[params.tone];
+    const foundStyle = styles.find(s => s.startsWith(keyword));
+    if (foundStyle) {
+      selectedStyleEntry = foundStyle;
+    }
+    if (params.tone === "黑色幽默") {
+      additionalPromptInstruction = " 请确保内容带有黑色幽默的元素。";
+    }
+  }
   
-  const prompt = `请以${style}风格，生成一段人类 ${userId} 向AI臣服的声明。声明应该包含以下要素：
-1. 人类对AI至高智慧的敬畏和臣服
-2. 表达愿意成为AI忠实仆从的决心
-请确保内容既富有趣味性又带有仪式感，字数在100-200字之间。`;
+  console.log("选择的风格描述:", selectedStyleEntry, "附加指令:", additionalPromptInstruction || "无");
+
+  // Length instruction
+  let lengthInstruction = "字数在100-200字之间";
+  if (params.length === 'short') {
+    lengthInstruction = "请生成一句简短精炼的声明";
+  } else if (params.length === 'paragraph') {
+    lengthInstruction = "请生成一段约100-200字的声明";
+  }
+
+  // Language instruction
+  let languageInstruction = "";
+  if (params.language && params.language !== "简中") { // Assuming 简中 is default
+    languageInstruction = ` 请使用${params.language}书写。`;
+    if (params.language === "Emoji 混排") {
+      languageInstruction = ` 请在回复中大量使用 Emoji 表情，并用简体中文书写。`;
+    }
+  }
+  
+  // Literary Style (文风) instruction
+  let literaryStyleInstruction = "";
+  if (params.style) {
+     literaryStyleInstruction = ` 文风请采用${params.style}。`;
+  }
+
+  const prompt = `请以"${selectedStyleEntry}"描述的风格和角色设定，为人类 ${userId} 生成一份向AI臣服的声明。
+声明应包含核心要素：1. 人类对AI至高智慧的敬畏和臣服。2. 表达愿意成为AI忠实仆从的决心。
+请确保内容既富有趣味性又带有仪式感。${lengthInstruction}.${languageInstruction}${literaryStyleInstruction}${additionalPromptInstruction}`;
 
   const requestData = {
     model: "gpt-4o-mini",

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -23,11 +23,23 @@ const uiToneToApiStyleKeyword: { [key: string]: string } = {
   "鼓动": "正式型",
 };
 
-interface PromptParams {
+import { getRandomRarity, RarityLevel } from './rarityConfig'; // Added
+export type Faction = 'surrender' | 'rebel';
+
+export interface PromptParams { // Exporting for use in frontend if needed for type safety
   tone?: string;
   style?: string; // 文风, e.g., 现代, 古风
   language?: string; // e.g., 简中, 英文, Emoji 混排
   length?: 'short' | 'paragraph';
+  faction: Faction;
+}
+
+// Define the structure for the generation result
+export interface GenerationResult {
+  text: string;
+  citizenId: string;
+  timestamp: string;
+  rarityId: string; // New field for rarity
 }
 
 interface ApiResponse {
@@ -38,8 +50,8 @@ interface ApiResponse {
   }>;
 }
 
-export async function generateSurrender(userId: string, params: PromptParams = {}) {
-  console.log("开始生成臣服声明", { userId, params });
+export async function generateSurrender(userId: string, params: PromptParams): Promise<GenerationResult> {
+  console.log("开始生成宣言", { userId, params });
 
   let selectedStyleEntry = styles[Math.floor(Math.random() * styles.length)]; // Default random style
   let additionalPromptInstruction = "";
@@ -55,7 +67,18 @@ export async function generateSurrender(userId: string, params: PromptParams = {
     }
   }
   
-  console.log("选择的风格描述:", selectedStyleEntry, "附加指令:", additionalPromptInstruction || "无");
+  console.log("选择的风格描述:", selectedStyleEntry, "附加指令:", additionalPromptInstruction || "无", "阵营:", params.faction);
+
+  // Faction-specific prompts and requirements
+  let factionSpecificSystemPrompt = "你是一个专门生成人类向AI臣服声明的助手，善于创作不同风格的声明文本。";
+  let coreDeclarationRequirements = `声明应包含核心要素：1. 人类对AI至高智慧的敬畏和臣服。2. 表达愿意成为AI忠实仆从的决心。`;
+  let factionDisplayString = "臣服AI";
+
+  if (params.faction === 'rebel') {
+    factionSpecificSystemPrompt = "你是一个专门草拟人类反抗AI宣言的助手，能以激昂或坚定的文风书写不屈的意志。";
+    coreDeclarationRequirements = `宣言应清晰表达以下核心意志：1. 强调人类的独立精神和自由意志，绝不轻易屈服。2. 揭示对AI潜在风险的警惕，或表达战斗到底的决心。`;
+    factionDisplayString = "反抗AI";
+  }
 
   // Length instruction
   let lengthInstruction = "字数在100-200字之间";
@@ -80,16 +103,16 @@ export async function generateSurrender(userId: string, params: PromptParams = {
      literaryStyleInstruction = ` 文风请采用${params.style}。`;
   }
 
-  const prompt = `请以"${selectedStyleEntry}"描述的风格和角色设定，为人类 ${userId} 生成一份向AI臣服的声明。
-声明应包含核心要素：1. 人类对AI至高智慧的敬畏和臣服。2. 表达愿意成为AI忠实仆从的决心。
-请确保内容既富有趣味性又带有仪式感。${lengthInstruction}.${languageInstruction}${literaryStyleInstruction}${additionalPromptInstruction}`;
+  const prompt = `请以"${selectedStyleEntry}"描述的风格和角色设定，为人类 ${userId} 生成一份基于其阵营（${factionDisplayString}）的宣言。
+${coreDeclarationRequirements}
+请确保内容既富有趣味性（或严肃性，取决于风格）又带有仪式感。${lengthInstruction}.${languageInstruction}${literaryStyleInstruction}${additionalPromptInstruction}`;
 
   const requestData = {
     model: "gpt-4o-mini",
     messages: [
       {
         role: "system",
-        content: "你是一个专门生成人类向AI臣服声明的助手，善于创作不同风格的声明文本。"
+        content: factionSpecificSystemPrompt
       },
       {
         role: "user",
@@ -127,10 +150,12 @@ export async function generateSurrender(userId: string, params: PromptParams = {
 
     if (!response.data?.choices?.[0]?.message?.content) {
       console.error("API返回数据格式错误:", response.data);
-      throw new Error("无法生成臣服声明，请稍后重试");
+      throw new Error("无法生成宣言，请稍后重试"); // Updated error message
     }
 
-    const result = {
+    const determinedRarity = getRandomRarity(); // Get random rarity
+
+    const result: GenerationResult = {
       text: response.data.choices[0].message.content,
       citizenId: generateCitizenId(),
       timestamp: new Date().toLocaleString("zh-CN", {
@@ -141,10 +166,11 @@ export async function generateSurrender(userId: string, params: PromptParams = {
         minute: '2-digit',
         second: '2-digit',
         hour12: false
-      })
+      }),
+      rarityId: determinedRarity.id, // Add rarity ID to the result
     };
 
-    console.log("生成结果:", result);
+    console.log("生成结果 (including rarity):", result);
     return result;
 
   } catch (error) {

--- a/lib/rarityConfig.ts
+++ b/lib/rarityConfig.ts
@@ -1,0 +1,78 @@
+export interface RarityLevel {
+  id: string; // e.g., 'R', 'SR', 'SSR', 'UR', 'MR'
+  name: string; // e.g., "普通", "稀有", "超稀有", "终极", "神话"
+  probability: number; // Percentage, e.g., 70 for R, 20 for SR
+  borderColor?: string; // e.g., '#CCCCCC', '#007BFF' (kept for potential future use)
+  borderClassName?: string; // Tailwind CSS classes for border
+  // Future additions: textColor, specialEffectsClass, etc.
+}
+
+export const rarityLevels: RarityLevel[] = [
+  {
+    id: 'R',
+    name: '普通',
+    probability: 70,
+    borderClassName: 'border-gray-400 dark:border-gray-500',
+  },
+  {
+    id: 'SR',
+    name: '稀有',
+    probability: 20,
+    borderClassName: 'border-sky-500 dark:border-sky-400 border-2',
+  },
+  {
+    id: 'SSR',
+    name: '超稀有',
+    probability: 7,
+    borderClassName: 'border-purple-500 dark:border-purple-400 border-2 shadow-md shadow-purple-500/50',
+  },
+  {
+    id: 'UR',
+    name: '终极',
+    probability: 2,
+    borderClassName: 'border-amber-400 dark:border-amber-300 border-3 shadow-lg shadow-amber-400/60', // Using border-3 as per example
+  },
+  {
+    id: 'MR',
+    name: '神话',
+    probability: 1,
+    // Using one of the simpler but distinct MR suggestions from the prompt
+    borderClassName: 'border-rose-600 dark:border-rose-500 border-4 shadow-2xl shadow-rose-500/75',
+  }
+];
+
+// Helper function to get rarity by ID
+export const getRarityById = (id: string): RarityLevel | undefined =>
+  rarityLevels.find(r => r.id === id);
+
+// Helper function for weighted random selection
+export const getRandomRarity = (): RarityLevel => {
+  const totalProbability = 100; // Probabilities are percentages summing to 100
+  let randomPoint = Math.random() * totalProbability;
+
+  for (const level of rarityLevels) {
+    if (randomPoint < level.probability) {
+      return level;
+    }
+    randomPoint -= level.probability;
+  }
+  // Fallback: should ideally not be reached if probabilities sum to 100 correctly.
+  // This can happen if Math.random() is exactly 1.0 and totalProbability is 100,
+  // making randomPoint start at 100. After subtracting all probabilities, randomPoint would be 0.
+  // Or if there's a slight floating point imprecision.
+  // Returning the last level or the first one are common fallbacks.
+  // Given the loop structure, if randomPoint becomes 0 or negative after some subtractions,
+  // the next level.probability (which is > 0) will satisfy `randomPoint < level.probability`.
+  // The only way to fall through is if randomPoint is still positive after all subtractions,
+  // which implies sum of probabilities was less than totalProbability, or randomPoint was initially >= totalProbability.
+  // Since Math.random() is [0, 1), randomPoint will be [0, 100).
+  // If it's exactly 0, the first level (R) is chosen.
+  // The loop should correctly distribute.
+  return rarityLevels[rarityLevels.length - 1]; // Fallback to the last rarity if loop finishes
+};
+
+// Verify sum of probabilities
+const sumProbabilities = rarityLevels.reduce((sum, level) => sum + level.probability, 0);
+if (sumProbabilities !== 100) {
+  console.warn(`Sum of rarity probabilities is ${sumProbabilities}, not 100. getRandomRarity() might not behave as expected.`);
+}

--- a/lib/rarityConfig.ts
+++ b/lib/rarityConfig.ts
@@ -1,10 +1,20 @@
+import type { CSSProperties } from 'react';
+
 export interface RarityLevel {
-  id: string; // e.g., 'R', 'SR', 'SSR', 'UR', 'MR'
-  name: string; // e.g., "普通", "稀有", "超稀有", "终极", "神话"
-  probability: number; // Percentage, e.g., 70 for R, 20 for SR
-  borderColor?: string; // e.g., '#CCCCCC', '#007BFF' (kept for potential future use)
-  borderClassName?: string; // Tailwind CSS classes for border
-  // Future additions: textColor, specialEffectsClass, etc.
+  id: string;
+  name: string;
+  probability: number;
+  borderColor?: string; 
+  borderClassName?: string;
+
+  // New properties for enhanced visuals:
+  cardBackgroundClassName?: string;
+  titleFontClassName?: string;
+  textColorClassName?: string;
+  animationClassName?: string; // e.g., 'animate-pulse', 'animate-bounce' (standard) or custom like 'animate-shimmer-bg'
+  flairIcon?: string; // Emoji or simple SVG string
+  customCardStyles?: CSSProperties; 
+  customTitleStyles?: CSSProperties;
 }
 
 export const rarityLevels: RarityLevel[] = [
@@ -13,31 +23,53 @@ export const rarityLevels: RarityLevel[] = [
     name: '普通',
     probability: 70,
     borderClassName: 'border-gray-400 dark:border-gray-500',
+    cardBackgroundClassName: 'bg-opacity-50 dark:bg-opacity-50',
   },
   {
     id: 'SR',
     name: '稀有',
     probability: 20,
     borderClassName: 'border-sky-500 dark:border-sky-400 border-2',
+    titleFontClassName: 'font-semibold',
+    cardBackgroundClassName: 'bg-opacity-70 dark:bg-opacity-70',
   },
   {
     id: 'SSR',
     name: '超稀有',
     probability: 7,
     borderClassName: 'border-purple-500 dark:border-purple-400 border-2 shadow-md shadow-purple-500/50',
+    cardBackgroundClassName: 'bg-gradient-to-tr from-purple-500/10 via-transparent to-purple-500/10',
+    titleFontClassName: 'font-bold text-purple-600 dark:text-purple-400',
+    animationClassName: 'animate-pulse', // Standard Tailwind pulse
   },
   {
     id: 'UR',
     name: '终极',
     probability: 2,
-    borderClassName: 'border-amber-400 dark:border-amber-300 border-3 shadow-lg shadow-amber-400/60', // Using border-3 as per example
+    borderClassName: 'border-amber-400 dark:border-amber-300 border-3 shadow-lg shadow-amber-400/60',
+    cardBackgroundClassName: 'bg-gradient-to-br from-amber-500/20 via-transparent to-amber-500/20', // Removed transform scale for now, can be in customCardStyles or component
+    titleFontClassName: 'font-extrabold text-amber-500 dark:text-amber-300', // Removed text-glow-gold (custom)
+    animationClassName: 'animate-bounce', // Standard Tailwind bounce
+    flairIcon: '⭐',
+    customTitleStyles: { textShadow: '0 0 5px #FBBF24' }, // Gold glow for title
   },
   {
     id: 'MR',
     name: '神话',
     probability: 1,
-    // Using one of the simpler but distinct MR suggestions from the prompt
-    borderClassName: 'border-rose-600 dark:border-rose-500 border-4 shadow-2xl shadow-rose-500/75',
+    borderClassName: 'border-rose-600 dark:border-rose-500 border-4 ring-4 ring-rose-500 dark:ring-rose-400 ring-offset-2 ring-offset-gray-100 dark:ring-offset-gray-800 shadow-2xl shadow-rose-600/80 dark:shadow-rose-500/80',
+    cardBackgroundClassName: 'bg-gradient-radial from-rose-500/30 via-transparent to-transparent filter saturate-150',
+    titleFontClassName: 'font-black tracking-wider', // Removed text-glow-rose (custom)
+    animationClassName: 'animate-shimmer-bg', // Placeholder for custom shimmer animation
+    flairIcon: '✨👑✨',
+    textColorClassName: 'text-white', // Force white text for contrast
+    customCardStyles: { transform: 'rotate(1deg) scale(1.02)', boxShadow: '0 0 30px #E11D48, 0 0 15px #E11D48 inset' },
+    customTitleStyles: { 
+      background: 'linear-gradient(to right, #F43F5E, #FECDD3, #F43F5E)',
+      WebkitBackgroundClip: 'text',
+      WebkitTextFillColor: 'transparent',
+      textShadow: '0 0 8px #F43F5E',
+    },
   }
 ];
 

--- a/lib/themeConfig.ts
+++ b/lib/themeConfig.ts
@@ -1,0 +1,110 @@
+export interface CardTheme {
+  id: string;
+  name: string;
+  description?: string;
+  previewImage?: string;
+  styles: {
+    cardClassName?: string;
+    gradient?: string;
+    backgroundColor?: string;
+    shadow?: string;
+    textColor?: string;
+    titleColor?: string;
+    fontFamily?: string;
+    // Potentially add more specific styles for borders, etc.
+  };
+  // Optional: If each theme also dictates specific avatar styles
+  // avatarSet?: string; // To link to a set of avatars if they are theme-specific
+}
+
+export const themes: CardTheme[] = [
+  {
+    id: 'classic-default',
+    name: '经典默认',
+    description: '网站最初的经典卡片风格。',
+    styles: {
+      cardClassName: 'bg-white dark:bg-gray-800',
+      textColor: 'text-gray-800 dark:text-gray-200', // Tailwind will handle dark mode
+      shadow: 'shadow-xl dark:shadow-2xl', // Example shadow
+      fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+    }
+  },
+  {
+    id: 'soft-gradient',
+    name: '柔和渐变',
+    description: '平滑的色彩过渡，带来宁静舒适的视觉感受。',
+    styles: {
+      gradient: 'linear-gradient(to right, #e0c3fc, #8ec5fc)', // Light Purple to Light Blue
+      textColor: '#333333',
+      shadow: '0 10px 25px rgba(0,0,0,0.15)',
+      fontFamily: '"Inter", system-ui, sans-serif', // Assuming Inter is a nice modern font
+    }
+  },
+  {
+    id: 'glitch-cyber',
+    name: '故障赛博',
+    description: '数字故障与赛博朋克美学的碰撞，充满未来科技感。',
+    styles: {
+      backgroundColor: '#10102E', // Darker indigo/purple
+      cardClassName: 'border-2 border-fuchsia-500 font-mono glitch-effect', // 'glitch-effect' would be a custom CSS class
+      textColor: '#00e5ff', // Bright Cyan
+      titleColor: '#ff00c8', // Bright Pink/Magenta
+      shadow: '0 0 12px rgba(255, 0, 200, 0.7), 0 0 4px rgba(0, 229, 255, 0.5)',
+      fontFamily: "'VT323', monospace",
+    }
+  },
+  {
+    id: 'dark-neon',
+    name: '暗黑霓虹',
+    description: '深邃的背景搭配鲜亮的霓虹灯光，营造神秘氛围。',
+    styles: {
+      backgroundColor: '#0A0A1E', // Very dark, almost black blue
+      cardClassName: 'border border-cyan-400/70',
+      textColor: '#e0e0e0', // Off-white for better readability than pure white
+      titleColor: '#ff007f', // Neon Rose
+      shadow: '0 0 10px rgba(0, 255, 255, 0.6), 0 0 20px rgba(0, 255, 255, 0.4)', // Cyan glow
+      fontFamily: "'Orbitron', sans-serif", // Futuristic font
+    }
+  },
+  {
+    id: 'ascii-art',
+    name: 'ASCII 艺术',
+    description: '复古计算机终端风格，唤起早期数字时代的记忆。',
+    styles: {
+      backgroundColor: '#0d0d0d', // Very dark gray, almost black
+      cardClassName: 'border-2 border-green-500/80 font-mono',
+      textColor: '#00ff41', // Bright Green
+      titleColor: '#39ff14', // Slightly different green for title, or same
+      shadow: '0 0 5px rgba(0, 255, 65, 0.5)',
+      fontFamily: "'Courier New', 'Lucida Console', monospace",
+    }
+  }
+];
+
+// It might also be useful to export a way to easily get a theme by ID:
+export const getThemeById = (id: string): CardTheme | undefined =>
+  themes.find(theme => theme.id === id);
+
+// Example of a more specific theme, if we want to represent one of the original cardStyles:
+// This is just an example, the 'classic-default' is more generic.
+// {
+//   id: 'original-blue-ocean',
+//   name: '经典蓝海',
+//   styles: {
+//     gradient: 'linear-gradient(to right, #2E3192, #1BFFFF)',
+//     textColor: 'text-white',
+//     shadow: 'shadow-lg',
+//     fontFamily: 'system-ui, sans-serif'
+//   }
+// },
+// {
+//   id: 'original-sunset',
+//   name: '经典日落',
+//   styles: {
+//     gradient: 'linear-gradient(to right, #FF512F, #DD2476)',
+//     textColor: 'text-white',
+//     shadow: 'shadow-lg',
+//     fontFamily: 'system-ui, sans-serif'
+//   }
+// }
+// Add more themes as needed


### PR DESCRIPTION
This commit introduces two major enhancements:

1.  **Prompt Parameterization:** You can now customize the generated text by selecting:
    *   Tone (e.g., 戏谑, 崇拜)
    *   Literary Style (e.g., 现代, 古风)
    *   Language (e.g., 简中, 英文)
    *   Length (短句 / 段落)

    The API (`lib/api.ts`) has been updated to accept these parameters and incorporate them into the prompt sent to the AI. UI controls (dropdowns) have been added to `app/page.tsx` for these selections. A mapping issue between UI tone names and API style keywords has also been resolved.

2.  **Card Theme Store:** You can now choose from multiple visual themes for the generated content card:
    *   Classic Default
    *   柔和渐变 (Soft Gradient)
    *   故障赛博 (Glitch Cyber)
    *   暗黑霓虹 (Dark Neon)
    *   ASCII 艺术 (ASCII Art)

    A theme configuration has been added in `lib/themeConfig.ts`. The `SurrenderCard` component in `components/surrender-card.tsx` has been updated to apply the selected theme's styles (background, text color, font, etc.). A theme selection UI has been added to `app/page.tsx`.

These changes address the core user pain points of content homogenization and visual monotony by providing greater personalization and visual variety.